### PR TITLE
Make fipsinstall -out flag optional

### DIFF
--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -376,7 +376,7 @@ opthelp:
 
     /* No extra arguments. */
     argc = opt_num_rest();
-    if (argc != 0)
+    if (argc != 0 || (verify && in_fname == NULL))
         goto opthelp;
 
     if (parent_config != NULL) {
@@ -389,9 +389,7 @@ opthelp:
         }
         goto end;
     }
-    if (module_fname == NULL
-            || (verify && in_fname == NULL)
-            || (!verify && out_fname == NULL))
+    if (module_fname == NULL)
         goto opthelp;
 
     tail = opt_path_end(module_fname);
@@ -490,7 +488,9 @@ opthelp:
         if (!load_fips_prov_and_run_self_test(prov_name))
             goto end;
 
-        fout = bio_open_default(out_fname, 'w', FORMAT_TEXT);
+        fout =
+            out_fname == NULL ? dup_bio_out(FORMAT_TEXT)
+                              : bio_open_default(out_fname, 'w', FORMAT_TEXT);
         if (fout == NULL) {
             BIO_printf(bio_err, "Failed to open file\n");
             goto end;

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -88,8 +88,8 @@ Filename to output the configuration data to; the default is standard output.
 
 =item B<-in> I<configfilename>
 
-Input filename to load configuration data from. Used with the B<-verify> option.
-Standard input is used if the filename is C<->.
+Input filename to load configuration data from.
+Must be used if the B<-verify> option is specified.
 
 =item B<-verify>
 

--- a/providers/build.info
+++ b/providers/build.info
@@ -150,7 +150,7 @@ IF[{- !$disabled{fips} -}]
   DEPEND[|tests|]=fipsmodule.cnf
   GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
         -module providers/$(FIPSMODULENAME) -provider_name fips \
-        -mac_name HMAC -section_name fips_sect -out -
+        -mac_name HMAC -section_name fips_sect
   DEPEND[fipsmodule.cnf]=$FIPSGOAL
 ENDIF
 


### PR DESCRIPTION
If -out is not specified, send output to stdout.
Fix documentation errors.
Remove "-out -" from an invocation.

Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
Reviewed-by: Richard Levitte <levitte@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/14623)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
